### PR TITLE
Add new keywords for GSoC 22 Reverse Lookup Index

### DIFF
--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -1,7 +1,7 @@
 Keywords
 ========
 
-Version: 0.7.2
+Version: 0.7.2+12.gd7f3491
 
 Access Control List Contains
 ----------------------------
@@ -330,6 +330,25 @@ Get the cache size.
 
 Outputs AFS cache size as the number of 1K blocks.
 
+Get Fid
+-------
+
+**Arguments**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Default value
+     - Notes
+   * - path
+     - 
+     - required
+
+**Documentation**
+
+Returns the FID of a given path in AFS.
+
 Get Inode
 ---------
 
@@ -348,6 +367,25 @@ Get Inode
 **Documentation**
 
 Returns the inode number of a path.
+
+Get Name By Fid
+---------------
+
+**Arguments**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Default value
+     - Notes
+   * - fid
+     - 
+     - required
+
+**Documentation**
+
+Returns the file name by FID.
 
 Get Version
 -----------


### PR DESCRIPTION
Add get fid keyword

Add keyword stub to lookup name by fid

Added reverse-index lookup kw: Get Name by FID

Also added a new command which uses a Python module to use RPC which in turn queries RIDB.  Executable to be stored in Variable RILOOKUP.

Added script code in get_name_by_fid method

RPC lib is now a part of OpenAFSLibrary

Updated get_name_by_fid() to take file server

Added keyword Should Not Be in RIDB to ensure FID is deleted from the RIDB.

Added 2 new keywords in path

1. Generate Simple RIDB: generates a hardcoded pre-defined sample file
2. Dump RIDB: Dumps RIDB. Needs root access and can only be run on FS.