### PR TITLE
Fall back to environment in variable lookup

### DIFF
--- a/OpenAFSLibrary/variable.py
+++ b/OpenAFSLibrary/variable.py
@@ -20,7 +20,9 @@
 #
 
 import sys
-from robot.libraries.BuiltIn import BuiltIn,RobotNotRunningError
+import os
+
+from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
 
 
 PY2 = (sys.version_info[0] == 2)
@@ -32,6 +34,25 @@ else:
 
 _rf = BuiltIn()
 
+_default_value = {
+    'AFS_CELL': 'example.com',
+    'KRB_AFS_KEYTAB': 'robot.keytab',
+    'KRB_REALM': 'EXAMPLE.COM',
+    'AFS_AKIMPERSONATE': False,
+    'PAG_ONEGROUP': True,
+    'AKLOG': 'aklog',
+    'BOS': 'bos',
+    'FS': 'fs',
+    'KDESTROY': 'kdestroy',
+    'KINIT': 'kinit',
+    'KLOG_KRB5': 'klog.krb5',
+    'PAGSH': 'pagsh',
+    'RXDEBUG': 'rxdebug',
+    'UNLOG': 'unlog',
+    'VOS': 'vos',
+}
+
+
 class VariableMissing(Exception):
     pass
 
@@ -42,14 +63,30 @@ def get_var(name):
     """Return the variable value as a string."""
     if not name:
         raise ValueError("get_var argument is missing!")
+
     try:
         value = _rf.get_variable_value("${%s}" % name)
     except AttributeError:
         value = None
+
+    if value is None:
+        try:
+            value = os.environ[name]
+        except KeyError:
+            value = None
+
+    if value is None:
+        try:
+            value = _default_value[name]
+        except KeyError:
+            value = None
+
     if value is None:
         raise VariableMissing(name)
+
     if value == "":
         raise VariableEmpty(name)
+
     return value
 
 def get_bool(name):

--- a/docs/source/variables.rst
+++ b/docs/source/variables.rst
@@ -1,37 +1,54 @@
 Variables
 =========
 
-The following variables should be configured in your test suite or in
-variable files to match your test system setup.
+The following environment variables are used to in the OpenAFSLibrary. These
+can be used to customize the keywords for your test setup.
+
+When running locally (Library import), the variables may be specified using
+Robot Framework test variables.
 
 .. list-table:: Test cell variables
    :header-rows: 1
 
    * - Name
      - Description
+     - Default
    * - AFS_CELL
      - Test cell name
+     - ``example.com``
    * - KRB_REALM
-     - Authentication realm (akimpersonate)
+     - Authentication realm
+     - ``EXAMPLE.COM``
    * - KRB_AFS_KEYTAB
-     - Authenication keytab (akimpersonate)
+     - Authenication keytab
+     - ``robot.keytab``
    * - AKLOG
      - ``aklog`` command path
+     - ``aklog``
    * - BOS
      - ``bos`` command path
+     - ``bos``
    * - FS
      - ``fs`` command path
+     - ``fs``
    * - PAGSH
      - ``pagsh`` commmand path
+     - ``pagsh``
    * - PTS
      - ``pts`` command path
+     - ``pts``
    * - RXDEBUG
      - ``rxdebug`` command path
+     - ``rxdebug``
    * - TOKENS
      - ``tokens`` command path
+     - ``tokens``
    * - UDEBUG
      - ``udebug`` command path
+     - ``udebug``
    * - UNLOG
      - ``unlog`` command path
+     - ``unlog``
    * - VOS
      - ``vos`` command path
+     - ``vos``


### PR DESCRIPTION
If a global variable is not found in the test variables, fall back to the current process enviroment variables. If not in the enviroment, fall back to a usable default value.