### PR TITLE
tox: Bump rf and python versions in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 minversion = 4.11.4
 env_list =
-    py{38,39,310,311,312}-rf611
-    py{38,39,310,311,312}-rf700
+    py{39,310,311,312}-rf611
+    py{39,310,311,312,313}-rf700
+    py{311,312,313}-rf732
 
 #
 # Usage:  tox [-e <testenv>] [-- <pytest-options>]
@@ -14,11 +15,16 @@ description = Run the tests
 package = wheel
 wheel_build_env = .pkg
 deps =
-    py{38,39,310,311,312}-rf611: robotframework==6.1.1
-    py{38,39,310,311,312}-rf700: robotframework==7.0.0
+    py{39,310,311,312}-rf611: robotframework==6.1.1
+    py{39,310,311,312,313}-rf700: robotframework==7.0.0
+    py{311,312,313}-rf732: robotframework==7.3.2
     pytest==7.4.4
 commands =
     pytest -v tests {posargs}
+
+#
+# Developer tasks with latest python.
+#
 
 
 #
@@ -31,48 +37,38 @@ commands =
 #
 [testenv:latest]
 description = Run the tests
-basepython = python3.11
+basepython = python3.13
 package = wheel
 wheel_build_env = .pkg
 deps =
-    robotframework==7.0.0
+    robotframework==7.3.2
     pytest==7.4.4
 commands =
     pytest -v tests {posargs}
 
-#
-# Usage:  tox -e dev
-#         source .tox/dev/bin/activate
-#
 [testenv:dev]
 description = Development environment
-basepython = python3.11
+basepython = python3.13
 usedevelop = True
 deps =
-    robotframework==7.0.0
+    robotframework==7.3.2
     pytest==7.4.4
     black==25.1.0
     flake8==7.0.0
     pyflakes==3.2.0
 commands =
 
-#
-# Usage:  tox -e format
-#
 [testenv:format]
 description = Reformat code
-basepython = python3.11
+basepython = python3.13
 deps =
     black==25.1.0
 commands =
     black OpenAFSLibrary tests
 
-#
-# Usage:  tox -e lint
-#
 [testenv:lint]
 description = Run static checks
-basepython = python3.11
+basepython = python3.13
 deps =
     black==25.1.0
     flake8==7.0.0
@@ -82,12 +78,9 @@ commands =
     pyflakes OpenAFSLibrary tests
     flake8 --ignore=E501 OpenAFSLibrary tests
 
-#
-# Usage:  tox -e docs
-#
 [testenv:docs]
 description = Build documentation
-basepython = python3.11
+basepython = python3.13
 changedir = docs
 deps =
     Sphinx==7.2.6
@@ -95,11 +88,9 @@ deps =
 commands =
     sphinx-build -M html source build
 
-#
-# Usage:  tox -e build
-#
 [testenv:build]
-basepython = python3.11
+description = Build package
+basepython = python3.13
 deps =
     build==1.0.3
     twine==6.1.0
@@ -107,13 +98,82 @@ commands =
     python -m build
     twine check dist/*
 
-#
-# Usage:  tox -e release
-#
 # Note: Set TWINE env vars or ~/.pypirc before running.
-#
 [testenv:release]
-basepython = python3.11
+description = Release package to pypi
+basepython = python3.13
+passenv =
+    TWINE_USERNAME
+    TWINE_PASSWORD
+    TWINE_REPOSITORY_URL
+deps =
+    build==1.0.3
+    twine==6.1.0
+commands =
+    python -m build
+    twine check dist/*
+    twine upload --repository robotframework-openafslibrary --skip-existing dist/*
+
+#
+# Developer tasks with Python 3.12
+#
+
+[testenv:dev-py312]
+description = Development environment (python 3.12)
+basepython = python3.12
+usedevelop = True
+deps =
+    robotframework==7.3.2
+    pytest==7.4.4
+    black==25.1.0
+    flake8==7.0.0
+    pyflakes==3.2.0
+commands =
+
+[testenv:format-py312]
+description = Reformat code with black (python 3.12)
+basepython = python3.12
+deps =
+    black==25.1.0
+commands =
+    black OpenAFSLibrary tests
+
+[testenv:lint-py312]
+description = Run static checks (python 3.12)
+basepython = python3.12
+deps =
+    black==25.1.0
+    flake8==7.0.0
+    pyflakes==3.2.0
+commands =
+    black --check OpenAFSLibrary tests
+    pyflakes OpenAFSLibrary tests
+    flake8 --ignore=E501 OpenAFSLibrary tests
+
+[testenv:docs-py312]
+description = Build documentation (python 3.12)
+basepython = python3.12
+changedir = docs
+deps =
+    Sphinx==7.2.6
+    sphinx-rtd-theme==2.0.0
+commands =
+    sphinx-build -M html source build
+
+[testenv:build-py312]
+description = Build package (python 3.12)
+basepython = python3.12
+deps =
+    build==1.0.3
+    twine==6.1.0
+commands =
+    python -m build
+    twine check dist/*
+
+# Note: Set TWINE env vars or ~/.pypirc before running.
+[testenv:release-py312]
+description = Build package to pypi (python 3.12)
+basepython = python3.12
 passenv =
     TWINE_USERNAME
     TWINE_PASSWORD


### PR DESCRIPTION
Add the latest Robotframework release

Bump the lastest Python to 3.13

Drop EOL python versions.

Add developer tasks for python 3.12 since we don't have python 3.13 everywhere yet.